### PR TITLE
Support to get token balance from Paraclear

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@starkware-industries/starkware-crypto-utils": "^0.2.1",
+    "bignumber.js": "^9.1.2",
     "starknet": "^6.6.6"
   },
   "devDependencies": {

--- a/src/account.ts
+++ b/src/account.ts
@@ -3,9 +3,10 @@ import { CallData, hash } from 'starknet';
 
 import type { ParadexConfig } from './config.js';
 import type { EthereumSigner, TypedData } from './ethereum-signer.js';
+import type { Hex } from './types.js';
 
-interface Account {
-  readonly address: string;
+export interface Account {
+  readonly address: Hex;
 }
 
 interface FromEthSignerParams {
@@ -57,11 +58,11 @@ function buildStarkKeyTypedData(l1ChainId: string): TypedData {
 
 interface GenerateAccountAddressParams {
   /** The hash of the account contract in hex format */
-  readonly accountClassHash: string;
+  readonly accountClassHash: Hex;
   /** The hash of the account proxy contract in hex format */
-  readonly accountProxyClassHash: string;
+  readonly accountProxyClassHash: Hex;
   /** The public key of the account in hex format */
-  readonly publicKey: string;
+  readonly publicKey: Hex;
 }
 
 /**
@@ -71,7 +72,7 @@ function generateAccountAddress({
   accountClassHash,
   accountProxyClassHash,
   publicKey,
-}: GenerateAccountAddressParams): string {
+}: GenerateAccountAddressParams): Hex {
   const callData = CallData.compile({
     implementation: accountClassHash,
     selector: hash.getSelectorFromName('initialize'),
@@ -88,5 +89,5 @@ function generateAccountAddress({
     0,
   );
 
-  return address;
+  return address as Hex;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,19 @@
 import * as _Account from './account.js';
 import * as _Config from './config.js';
 import * as _Signer from './ethereum-signer.js';
+import * as _ParaclearProvider from './paraclear-provider.js';
+import * as _Paraclear from './paraclear.js';
 
 export const Config = { fetchConfig: _Config.fetchConfig };
 
 export const Account = { fromEthSigner: _Account.fromEthSigner };
 
 export const Signer = { ethersSignerAdapter: _Signer.ethersSignerAdapter };
+
+export const ParaclearProvider = {
+  DefaultProvider: _ParaclearProvider.DefaultProvider,
+};
+
+export const Paraclear = {
+  getTokenBalance: _Paraclear.getTokenBalance,
+};

--- a/src/paraclear-provider.ts
+++ b/src/paraclear-provider.ts
@@ -1,0 +1,14 @@
+import * as Starknet from 'starknet';
+
+import type { ParadexConfig } from './config.js';
+
+export class DefaultProvider extends Starknet.RpcProvider {
+  constructor(config: ParadexConfig) {
+    super({
+      nodeUrl: config.starknetFullNodeRpcUrl,
+      chainId: config.starknetChainId as Starknet.RpcProviderOptions['chainId'],
+    });
+  }
+}
+
+export type ParaclearProvider = DefaultProvider;

--- a/src/paraclear.ts
+++ b/src/paraclear.ts
@@ -1,0 +1,73 @@
+import { BigNumber } from 'bignumber.js';
+import * as Starknet from 'starknet';
+
+import type { Account } from './account.js';
+import type { ParadexConfig } from './config.js';
+import type { ParaclearProvider } from './paraclear-provider.js';
+
+interface GetBalanceParams {
+  readonly config: ParadexConfig;
+  readonly provider: Pick<ParaclearProvider, 'callContract'>;
+  /**
+   * Account to get the balance for.
+   */
+  readonly account: Pick<Account, 'address'>;
+  /**
+   * Token symbol.
+   * @example 'USDC'
+   */
+  readonly token: string;
+}
+
+interface GetBalanceResult {
+  /**
+   * Token balance as a decimal string.
+   * @example '100.45'
+   * @example '45.2'
+   */
+  readonly size: string;
+}
+
+/**
+ * Get the Paraclear balance of the given token for the given account.
+ */
+export async function getTokenBalance(
+  params: GetBalanceParams,
+): Promise<GetBalanceResult> {
+  const token = params.config.bridgedTokens[params.token];
+
+  if (token == null) {
+    throw new Error(`Token ${params.token} is not supported`);
+  }
+
+  const [result] = await params.provider.callContract(
+    {
+      contractAddress: params.config.paraclearAddress,
+      entrypoint: 'getTokenAssetBalance',
+      calldata: Starknet.CallData.compile([
+        params.account.address,
+        token.l2TokenAddress,
+      ]),
+    },
+    'latest',
+  );
+
+  if (result == null) {
+    throw new Error('Failed to get token balance');
+  }
+
+  const resultBn = new BigNumber(result);
+  if (resultBn.isNaN()) {
+    throw new Error('Failed to parse token balance');
+  }
+
+  const chainSizeBn = resultBn;
+
+  const sizeBn = fromChainSize(chainSizeBn, params.config.paraclearDecimals);
+
+  return { size: sizeBn.toString() };
+}
+
+function fromChainSize(size: BigNumber, decimals: number): string {
+  return new BigNumber(size).div(10 ** decimals).toString();
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,1 @@
+export type Hex = `0x${string}`;

--- a/tests/account.test.ts
+++ b/tests/account.test.ts
@@ -3,7 +3,7 @@ import { ethers } from 'ethers';
 import * as Account from '../src/account';
 import { ethersSignerAdapter } from '../src/ethereum-signer';
 
-import PARADEX_CONFIG from './fixtures/paradex-config.json';
+import { configFactory } from './factories/paradex-config';
 
 describe('create account from eth signer', () => {
   test('correct account address is generated', async () => {
@@ -30,7 +30,7 @@ describe('create account from eth signer', () => {
       const signer = ethersSignerAdapter(wallet);
 
       const account = await Account.fromEthSigner({
-        config: PARADEX_CONFIG,
+        config: configFactory(),
         signer,
       });
 

--- a/tests/factories/paradex-config.ts
+++ b/tests/factories/paradex-config.ts
@@ -1,0 +1,29 @@
+import type { ParadexConfig } from '../../src/config';
+
+export function configFactory(): ParadexConfig {
+  return {
+    starknetFullNodeRpcUrl: 'https://example-fullnode-rpc-url.com',
+    starknetChainId: '42',
+    l1ChainId: '11155111',
+    paraclearAccountHash:
+      '0x41cb0280ebadaa75f996d8d92c6f265f6d040bb3ba442e5f86a554f1765244e',
+    paraclearAccountProxyHash:
+      '0x3530cc4759d78042f1b543bf797f5f3d647cde0388c33734cf91b7f7b9314a9',
+    paraclearAddress:
+      '0x286003f7c7bfc3f94e8f0af48b48302e7aee2fb13c23b141479ba00832ef2c6',
+    paraclearDecimals: 8,
+    bridgedTokens: {
+      USDC: {
+        name: 'USD Coin',
+        symbol: 'USDC',
+        decimals: 6,
+        l1TokenAddress: '0x29A873159D5e14AcBd63913D4A7E2df04570c666',
+        l1BridgeAddress: '0x8586e05adc0C35aa11609023d4Ae6075Cb813b4C',
+        l2TokenAddress:
+          '0x6f373b346561036d98ea10fb3e60d2f459c872b1933b50b21fe6ef4fda3b75e',
+        l2BridgeAddress:
+          '0x46e9237f5408b5f899e72125dd69bd55485a287aaf24663d3ebe00d237fc7ef',
+      },
+    },
+  };
+}

--- a/tests/fixtures/paradex-config.json
+++ b/tests/fixtures/paradex-config.json
@@ -1,5 +1,0 @@
-{
-  "l1ChainId": "11155111",
-  "paraclearAccountHash": "0x41cb0280ebadaa75f996d8d92c6f265f6d040bb3ba442e5f86a554f1765244e",
-  "paraclearAccountProxyHash": "0x3530cc4759d78042f1b543bf797f5f3d647cde0388c33734cf91b7f7b9314a9"
-}

--- a/tests/paraclear.test.ts
+++ b/tests/paraclear.test.ts
@@ -1,0 +1,61 @@
+import { getTokenBalance } from '../src/paraclear';
+
+import { configFactory } from './factories/paradex-config';
+
+describe('getBalance', () => {
+  test('should return the balance size', async () => {
+    const mockProvider = { callContract: jest.fn() };
+    mockProvider.callContract.mockResolvedValueOnce([9900000000]);
+
+    const result = await getTokenBalance({
+      config: configFactory(),
+      provider: mockProvider,
+      account: { address: '0x123456789' },
+      token: 'USDC',
+    });
+
+    expect(result).toEqual({ size: '99' });
+  });
+
+  test('should throw an error if token is not supported', async () => {
+    const mockProvider = { callContract: jest.fn() };
+    mockProvider.callContract.mockResolvedValueOnce([9900000000]);
+
+    const result = getTokenBalance({
+      config: configFactory(),
+      provider: mockProvider,
+      account: { address: '0x123456789' },
+      token: 'ASDF',
+    });
+
+    await expect(result).rejects.toThrow('Token ASDF is not supported');
+  });
+
+  test('should throw an error if calling the contract returns no value', async () => {
+    const mockProvider = { callContract: jest.fn() };
+    mockProvider.callContract.mockResolvedValueOnce([]);
+
+    const result = getTokenBalance({
+      config: configFactory(),
+      provider: mockProvider,
+      account: { address: '0x123456789' },
+      token: 'USDC',
+    });
+
+    await expect(result).rejects.toThrow('Failed to get token balance');
+  });
+
+  test('should throw an error if balance parsing fails', async () => {
+    const mockProvider = { callContract: jest.fn() };
+    mockProvider.callContract.mockResolvedValueOnce(['not a number']);
+
+    const result = getTokenBalance({
+      config: configFactory(),
+      provider: mockProvider,
+      account: { address: '0x123456789' },
+      token: 'USDC',
+    });
+
+    await expect(result).rejects.toThrow('Failed to parse token balance');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1231,6 +1231,11 @@ base64-js@^1.3.1:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
+bignumber.js@^9.1.2:
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.2.tgz#b7c4242259c008903b13707983b5f4bbd31eda0c"
+  integrity sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==
+
 bip39@^3.0.4:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/bip39/-/bip39-3.1.0.tgz#c55a418deaf48826a6ceb34ac55b3ee1577e18a3"


### PR DESCRIPTION
* Add `getTokenBalance` method to the new `Paraclear` module
* Getting balance is part of withdrawal workflow, feature that will be added in the near future.
* Passing `config` and `provider` to `getTokenBalance` is an intentional design choice to allow for flexibility in the future. Better abstractions can be created later as we better understand the use cases.