### PR TITLE
Support for withdrawal with batched arbitrary bridge transaction + example

### DIFF
--- a/examples/withdrawal.ts
+++ b/examples/withdrawal.ts
@@ -1,0 +1,89 @@
+import { ethers } from 'ethers';
+
+import * as Paradex from '../src/index.js';
+
+declare global {
+  interface Window {
+    ethereum?: ethers.Eip1193Provider;
+  }
+}
+
+// Flow summary:
+//  1. Fetch Paradex config
+//  2. Create Paraclear provider
+//  3. Derive Paradex account from Ethereum signer
+//  4. Get user's USDC balance
+//  5. Withdraw USDC
+
+// 1. Fetch Paradex config for the relevant environment
+const config = await Paradex.Config.fetchConfig('testnet'); // "testnet" | "mainnet"
+
+// 2. Create Paraclear provider
+const paraclearProvider = new Paradex.ParaclearProvider.DefaultProvider(config);
+
+// 3. Derive Paradex account from Ethereum signer
+
+//  3.1. Get ethers signer (example with injected provider)
+if (window.ethereum == null) throw new Error('Ethereum provider not found');
+const ethersProvider = new ethers.BrowserProvider(window.ethereum);
+const ethersSigner = await ethersProvider.getSigner();
+
+//  3.2. Create Ethereum signer based on ethers signer
+const signer = Paradex.Signer.ethersSignerAdapter(ethersSigner);
+
+//  3.3. Initialize the account with config and Ethereum signer
+const account = await Paradex.Account.fromEthSigner({
+  provider: paraclearProvider,
+  config,
+  signer,
+});
+
+// 4. Get user's USDC balance
+const getBalanceResult = await Paradex.Paraclear.getTokenBalance({
+  provider: paraclearProvider, // account can be passed as the provider
+  config,
+  account,
+  token: 'USDC',
+});
+console.log(getBalanceResult); // { size: '100.45' }
+
+// 5. Withdrawal
+
+//  5.1. Get receivable amount and socialized loss factor
+const receivableAmountResult = await Paradex.Paraclear.getReceivableAmount({
+  provider: paraclearProvider, // account can be passed as the provider
+  config,
+  amount: '50.4',
+});
+
+//  5.2. Check if socialized loss factor is not 0
+if (Number(receivableAmountResult.socializedLossFactor) !== 0) {
+  // Display a warning to the user, suggesting to withdraw a smaller
+  // amount or to wait for the socialized loss factor to decrease.
+  console.log(
+    `Socialized loss is active. You will receive` +
+      ` ${receivableAmountResult.receivableAmount} USDC.`,
+  );
+}
+
+//  5.3. Request withdrawal (batches 1. withdraw from Paraclear contract
+//  and 2. deposit to the bridge in `bridgeCall`) for atomic transaction.
+//  Note that the requested withdraw amount can be different from the amount
+//  that will be received if socialized loss is active. Use the receivable
+//  amount to make the bridge call.
+const withdrawResult = await Paradex.Paraclear.withdraw({
+  config,
+  account,
+  token: 'USDC',
+  amount: '50.4',
+  bridgeCall: {
+    contractAddress: '0x...',
+    entrypoint: 'deposit',
+    calldata: ['...', receivableAmountResult.receivableAmountChain],
+  },
+});
+console.log(withdrawResult); // { hash: '0x...' }
+
+//  5.4. Monitor batch withdrawal transaction to completion
+//  https://www.starknetjs.com/docs/api/classes/providerinterface/#waitfortransaction
+await paraclearProvider.waitForTransaction(withdrawResult.hash);

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@starkware-industries/starkware-crypto-utils": "^0.2.1",
     "bignumber.js": "^9.1.2",
-    "starknet": "^6.6.6"
+    "starknet": "^5.24.3"
   },
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^4.2.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,4 +16,6 @@ export const ParaclearProvider = {
 
 export const Paraclear = {
   getTokenBalance: _Paraclear.getTokenBalance,
+  getSocializedLossFactor: _Paraclear.getSocializedLossFactor,
+  getReceivableAmount: _Paraclear.getReceivableAmount,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,4 +18,5 @@ export const Paraclear = {
   getTokenBalance: _Paraclear.getTokenBalance,
   getSocializedLossFactor: _Paraclear.getSocializedLossFactor,
   getReceivableAmount: _Paraclear.getReceivableAmount,
+  withdraw: _Paraclear.withdraw,
 };

--- a/src/paraclear.ts
+++ b/src/paraclear.ts
@@ -40,7 +40,7 @@ export async function getTokenBalance(
     throw new Error(`Token ${params.token} is not supported`);
   }
 
-  const [result] = await params.provider.callContract(
+  const { result } = await params.provider.callContract(
     {
       contractAddress: params.config.paraclearAddress,
       entrypoint: 'getTokenAssetBalance',
@@ -52,16 +52,18 @@ export async function getTokenBalance(
     'latest',
   );
 
-  if (result == null) {
+  const value = result?.[0];
+
+  if (value == null) {
     throw new Error('Failed to get token balance');
   }
 
-  const resultBn = new BigNumber(result);
-  if (resultBn.isNaN()) {
+  const valueBn = new BigNumber(value);
+  if (valueBn.isNaN()) {
     throw new Error('Failed to parse token balance');
   }
 
-  const chainSizeBn = resultBn;
+  const chainSizeBn = valueBn;
 
   const sizeBn = fromChainSize(chainSizeBn, params.config.paraclearDecimals);
 
@@ -87,21 +89,23 @@ interface GetSocializedLossFactorResult {
 export async function getSocializedLossFactor(
   params: GetSocializedLossFactorParams,
 ): Promise<GetSocializedLossFactorResult> {
-  const [result] = await params.provider.callContract({
+  const { result } = await params.provider.callContract({
     contractAddress: params.config.paraclearAddress,
     entrypoint: 'getSocializedLossFactor',
   });
 
-  if (result == null) {
+  const value = result?.[0];
+
+  if (value == null) {
     throw new Error('Failed to get socialized loss factor');
   }
 
-  const resultBn = new BigNumber(result);
-  if (resultBn.isNaN()) {
+  const valueBn = new BigNumber(value);
+  if (valueBn.isNaN()) {
     throw new Error('Failed to parse socialized loss factor');
   }
 
-  const chainFactorBn = resultBn;
+  const chainFactorBn = valueBn;
 
   const factorBn = fromChainSize(
     chainFactorBn,

--- a/src/paraclear.ts
+++ b/src/paraclear.ts
@@ -68,6 +68,123 @@ export async function getTokenBalance(
   return { size: sizeBn.toString() };
 }
 
+interface GetSocializedLossFactorParams {
+  readonly config: ParadexConfig;
+  readonly provider: Pick<ParaclearProvider, 'callContract'>;
+}
+
+interface GetSocializedLossFactorResult {
+  readonly socializedLossFactor: string;
+}
+
+/**
+ * Socialized losses happen when Paradex Insurance Fund is bankrupt
+ * due to large amounts of unprofitable liquidations. When socialized
+ * losses are active, (socialized loss factor > 0), the amount that
+ * the user will receive when withdrawing will be smaller than the
+ * requested amount.
+ */
+export async function getSocializedLossFactor(
+  params: GetSocializedLossFactorParams,
+): Promise<GetSocializedLossFactorResult> {
+  const [result] = await params.provider.callContract({
+    contractAddress: params.config.paraclearAddress,
+    entrypoint: 'getSocializedLossFactor',
+  });
+
+  if (result == null) {
+    throw new Error('Failed to get socialized loss factor');
+  }
+
+  const resultBn = new BigNumber(result);
+  if (resultBn.isNaN()) {
+    throw new Error('Failed to parse socialized loss factor');
+  }
+
+  const chainFactorBn = resultBn;
+
+  const factorBn = fromChainSize(
+    chainFactorBn,
+    params.config.paraclearDecimals,
+  );
+
+  return { socializedLossFactor: factorBn.toString() };
+}
+
+interface GetReceivableAmountParams {
+  readonly config: ParadexConfig;
+  readonly provider: Pick<ParaclearProvider, 'callContract'>;
+  /**
+   * Amount of to withdraw from Paradex, as a decimal string.
+   * The receivable amount will be calculated based on this amount and
+   * can be less than the requested amount if socialized loss is active.
+   */
+  readonly amount: string;
+}
+
+interface GetReceivableAmountResult {
+  /**
+   * Amount that will be received from Paradex, after socialized loss,
+   * if applicable, after a withdrawal of the given amount parameter.
+   * Decimal string.
+   * @example '99.45'
+   */
+  readonly receivableAmount: string;
+  /**
+   * The receivable amount, converted to be used in chain calls,
+   * using the Paraclear decimals.
+   * @example '9945000000'
+   */
+  readonly receivableAmountChain: string;
+  /**
+   * Socialized loss factor used to calculate the receivable amount.
+   * Decimal string.
+   * @example '0.05'
+   */
+  readonly socializedLossFactor: string;
+}
+
+/**
+ * The receivable amount is calculated based on the current
+ * socialized loss factor: amount * (1 - socializedLossFactor)
+ *
+ * If the socialized loss factor is 0, the receivable amount
+ * will be equal to the requested amount.
+ */
+export async function getReceivableAmount(
+  params: GetReceivableAmountParams,
+): Promise<GetReceivableAmountResult> {
+  const amountBn = new BigNumber(params.amount);
+
+  if (amountBn.isNaN()) {
+    throw new Error('Invalid amount');
+  }
+
+  const { socializedLossFactor } = await getSocializedLossFactor({
+    config: params.config,
+    provider: params.provider,
+  });
+
+  const receivableAmount = amountBn.times(
+    BigNumber(1).minus(socializedLossFactor),
+  );
+
+  const receivableAmountChain = toChainSize(
+    receivableAmount.toString(),
+    params.config.paraclearDecimals,
+  );
+
+  return {
+    receivableAmount: receivableAmount.toString(),
+    receivableAmountChain: receivableAmountChain.toString(),
+    socializedLossFactor,
+  };
+}
+
 function fromChainSize(size: BigNumber, decimals: number): string {
   return new BigNumber(size).div(10 ** decimals).toString();
+}
+
+function toChainSize(size: string, decimals: number): BigNumber {
+  return new BigNumber(size).times(10 ** decimals);
 }

--- a/tests/account.test.ts
+++ b/tests/account.test.ts
@@ -4,6 +4,7 @@ import * as Account from '../src/account';
 import { ethersSignerAdapter } from '../src/ethereum-signer';
 
 import { configFactory } from './factories/paradex-config';
+import { createMockProvider } from './mocks/provider';
 
 describe('create account from eth signer', () => {
   test('correct account address is generated', async () => {
@@ -30,6 +31,7 @@ describe('create account from eth signer', () => {
       const signer = ethersSignerAdapter(wallet);
 
       const account = await Account.fromEthSigner({
+        provider: createMockProvider(),
         config: configFactory(),
         signer,
       });

--- a/tests/mocks/provider.ts
+++ b/tests/mocks/provider.ts
@@ -1,0 +1,5 @@
+import * as Starknet from 'starknet';
+
+export function createMockProvider(): Starknet.RpcProvider {
+  return new Starknet.RpcProvider({ nodeUrl: 'mock-provider' });
+}

--- a/tests/paraclear.test.ts
+++ b/tests/paraclear.test.ts
@@ -1,10 +1,17 @@
+import { ethers } from 'ethers';
+import * as Starknet from 'starknet';
+
+import { fromEthSigner } from '../src/account';
+import { ethersSignerAdapter } from '../src/ethereum-signer';
 import {
   getReceivableAmount,
   getSocializedLossFactor,
   getTokenBalance,
+  withdraw,
 } from '../src/paraclear';
 
 import { configFactory } from './factories/paradex-config';
+import { createMockProvider } from './mocks/provider';
 
 describe('getBalance', () => {
   test('should return the balance size', async () => {
@@ -172,6 +179,85 @@ describe('getReceivableAmount', () => {
 
     await expect(result).rejects.toThrow(
       'Failed to get socialized loss factor',
+    );
+  });
+});
+
+describe('withdraw', () => {
+  test('should initiate withdrawal and return transaction hash', async () => {
+    const wallet = ethers.Wallet.fromPhrase(
+      'test test test test test test test test test test test waste',
+    );
+    const signer = ethersSignerAdapter(wallet);
+
+    const config = configFactory();
+
+    const mockAccount = await fromEthSigner({
+      provider: createMockProvider(),
+      config,
+      signer,
+    });
+
+    jest.spyOn(mockAccount, 'execute').mockResolvedValueOnce({
+      transaction_hash: '0xabcdef123456',
+    });
+
+    const bridgeCall = {
+      contractAddress: '0xB',
+      entrypoint: 'deposit',
+      calldata: Starknet.CallData.compile(['0x12', '100000000']),
+    };
+
+    const result = await withdraw({
+      config,
+      account: mockAccount,
+      token: 'USDC',
+      amount: '100',
+      bridgeCall,
+    });
+
+    if (config.bridgedTokens.USDC == null) {
+      throw new Error('Token USDC is not defined');
+    }
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(mockAccount.execute).toHaveBeenCalledWith([
+      {
+        contractAddress:
+          '0x286003f7c7bfc3f94e8f0af48b48302e7aee2fb13c23b141479ba00832ef2c6',
+        entrypoint: 'initiate_withdrawal',
+        calldata: Starknet.CallData.compile([
+          config.bridgedTokens.USDC.l2TokenAddress,
+          '10000000000',
+        ]),
+      },
+      bridgeCall,
+    ]);
+
+    expect(result).toEqual({ hash: '0xabcdef123456' });
+  });
+
+  test('should throw an error if token is not supported', async () => {
+    const wallet = ethers.Wallet.fromPhrase(
+      'test test test test test test test test test test test waste',
+    );
+    const signer = ethersSignerAdapter(wallet);
+    const mockAccount = await fromEthSigner({
+      provider: createMockProvider(),
+      config: configFactory(),
+      signer,
+    });
+
+    const withdrawParams = {
+      config: configFactory(),
+      account: mockAccount,
+      token: 'ASDF',
+      amount: '100',
+      bridgeCall: { contractAddress: '', entrypoint: '', calldata: [] },
+    };
+
+    await expect(withdraw(withdrawParams)).rejects.toThrow(
+      'Token ASDF is not supported',
     );
   });
 });

--- a/tests/paraclear.test.ts
+++ b/tests/paraclear.test.ts
@@ -1,4 +1,8 @@
-import { getTokenBalance } from '../src/paraclear';
+import {
+  getReceivableAmount,
+  getSocializedLossFactor,
+  getTokenBalance,
+} from '../src/paraclear';
 
 import { configFactory } from './factories/paradex-config';
 
@@ -57,5 +61,111 @@ describe('getBalance', () => {
     });
 
     await expect(result).rejects.toThrow('Failed to parse token balance');
+  });
+});
+
+describe('getSocializedLossFactor', () => {
+  test('should return the socialized loss factor', async () => {
+    const mockProvider = { callContract: jest.fn() };
+    mockProvider.callContract.mockResolvedValueOnce(['123456789']);
+
+    const result = await getSocializedLossFactor({
+      config: configFactory(),
+      provider: mockProvider,
+    });
+
+    expect(result).toEqual({ socializedLossFactor: '1.23456789' });
+  });
+
+  test('should throw an error if the result is null', async () => {
+    const mockProvider = { callContract: jest.fn() };
+    mockProvider.callContract.mockResolvedValueOnce([null]);
+
+    const result = getSocializedLossFactor({
+      config: configFactory(),
+      provider: mockProvider,
+    });
+
+    await expect(result).rejects.toThrow(
+      'Failed to get socialized loss factor',
+    );
+  });
+
+  test('should throw an error if the result is not a number', async () => {
+    const mockProvider = { callContract: jest.fn() };
+    mockProvider.callContract.mockResolvedValueOnce(['not a number']);
+
+    const result = getSocializedLossFactor({
+      config: configFactory(),
+      provider: mockProvider,
+    });
+
+    await expect(result).rejects.toThrow(
+      'Failed to parse socialized loss factor',
+    );
+  });
+});
+
+describe('getReceivableAmount', () => {
+  test('should calculate the receivable amount correctly', async () => {
+    const socializedLossFactor = '0.01';
+    const socializedLossFactorChain = '1000000';
+
+    const mockProvider = { callContract: jest.fn() };
+    mockProvider.callContract.mockResolvedValueOnce([
+      socializedLossFactorChain,
+    ]);
+
+    const result = await getReceivableAmount({
+      config: configFactory(),
+      provider: mockProvider,
+      amount: '100',
+    });
+
+    expect(result).toStrictEqual({
+      receivableAmount: '99',
+      receivableAmountChain: '9900000000',
+      socializedLossFactor,
+    });
+  });
+
+  test('should throw an error for invalid amount', async () => {
+    const result = getReceivableAmount({
+      config: configFactory(),
+      provider: { callContract: jest.fn() },
+      amount: 'not a number',
+    });
+
+    await expect(result).rejects.toThrow('Invalid amount');
+  });
+
+  test('should throw an error if socialized loss factor is not a number', async () => {
+    const mockProvider = { callContract: jest.fn() };
+    mockProvider.callContract.mockResolvedValueOnce(['not a number']);
+
+    const result = getReceivableAmount({
+      config: configFactory(),
+      provider: mockProvider,
+      amount: '100',
+    });
+
+    await expect(result).rejects.toThrow(
+      'Failed to parse socialized loss factor',
+    );
+  });
+
+  test('should throw an error if socialized loss factor is null', async () => {
+    const mockProvider = { callContract: jest.fn() };
+    mockProvider.callContract.mockResolvedValueOnce([null]);
+
+    const result = getReceivableAmount({
+      config: configFactory(),
+      provider: mockProvider,
+      amount: '100',
+    });
+
+    await expect(result).rejects.toThrow(
+      'Failed to get socialized loss factor',
+    );
   });
 });

--- a/tests/paraclear.test.ts
+++ b/tests/paraclear.test.ts
@@ -9,7 +9,7 @@ import { configFactory } from './factories/paradex-config';
 describe('getBalance', () => {
   test('should return the balance size', async () => {
     const mockProvider = { callContract: jest.fn() };
-    mockProvider.callContract.mockResolvedValueOnce([9900000000]);
+    mockProvider.callContract.mockResolvedValueOnce({ result: [9900000000] });
 
     const result = await getTokenBalance({
       config: configFactory(),
@@ -23,7 +23,7 @@ describe('getBalance', () => {
 
   test('should throw an error if token is not supported', async () => {
     const mockProvider = { callContract: jest.fn() };
-    mockProvider.callContract.mockResolvedValueOnce([9900000000]);
+    mockProvider.callContract.mockResolvedValueOnce({ result: [9900000000] });
 
     const result = getTokenBalance({
       config: configFactory(),
@@ -37,7 +37,7 @@ describe('getBalance', () => {
 
   test('should throw an error if calling the contract returns no value', async () => {
     const mockProvider = { callContract: jest.fn() };
-    mockProvider.callContract.mockResolvedValueOnce([]);
+    mockProvider.callContract.mockResolvedValueOnce({ result: [] });
 
     const result = getTokenBalance({
       config: configFactory(),
@@ -51,7 +51,9 @@ describe('getBalance', () => {
 
   test('should throw an error if balance parsing fails', async () => {
     const mockProvider = { callContract: jest.fn() };
-    mockProvider.callContract.mockResolvedValueOnce(['not a number']);
+    mockProvider.callContract.mockResolvedValueOnce({
+      result: ['not a number'],
+    });
 
     const result = getTokenBalance({
       config: configFactory(),
@@ -67,7 +69,7 @@ describe('getBalance', () => {
 describe('getSocializedLossFactor', () => {
   test('should return the socialized loss factor', async () => {
     const mockProvider = { callContract: jest.fn() };
-    mockProvider.callContract.mockResolvedValueOnce(['123456789']);
+    mockProvider.callContract.mockResolvedValueOnce({ result: ['123456789'] });
 
     const result = await getSocializedLossFactor({
       config: configFactory(),
@@ -79,7 +81,7 @@ describe('getSocializedLossFactor', () => {
 
   test('should throw an error if the result is null', async () => {
     const mockProvider = { callContract: jest.fn() };
-    mockProvider.callContract.mockResolvedValueOnce([null]);
+    mockProvider.callContract.mockResolvedValueOnce({ result: [null] });
 
     const result = getSocializedLossFactor({
       config: configFactory(),
@@ -93,7 +95,9 @@ describe('getSocializedLossFactor', () => {
 
   test('should throw an error if the result is not a number', async () => {
     const mockProvider = { callContract: jest.fn() };
-    mockProvider.callContract.mockResolvedValueOnce(['not a number']);
+    mockProvider.callContract.mockResolvedValueOnce({
+      result: ['not a number'],
+    });
 
     const result = getSocializedLossFactor({
       config: configFactory(),
@@ -112,9 +116,9 @@ describe('getReceivableAmount', () => {
     const socializedLossFactorChain = '1000000';
 
     const mockProvider = { callContract: jest.fn() };
-    mockProvider.callContract.mockResolvedValueOnce([
-      socializedLossFactorChain,
-    ]);
+    mockProvider.callContract.mockResolvedValueOnce({
+      result: [socializedLossFactorChain],
+    });
 
     const result = await getReceivableAmount({
       config: configFactory(),
@@ -141,7 +145,9 @@ describe('getReceivableAmount', () => {
 
   test('should throw an error if socialized loss factor is not a number', async () => {
     const mockProvider = { callContract: jest.fn() };
-    mockProvider.callContract.mockResolvedValueOnce(['not a number']);
+    mockProvider.callContract.mockResolvedValueOnce({
+      result: ['not a number'],
+    });
 
     const result = getReceivableAmount({
       config: configFactory(),
@@ -156,7 +162,7 @@ describe('getReceivableAmount', () => {
 
   test('should throw an error if socialized loss factor is null', async () => {
     const mockProvider = { callContract: jest.fn() };
-    mockProvider.callContract.mockResolvedValueOnce([null]);
+    mockProvider.callContract.mockResolvedValueOnce({ result: [null] });
 
     const result = getReceivableAmount({
       config: configFactory(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -611,41 +611,22 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@noble/curves@1.2.0":
+"@noble/curves@1.2.0", "@noble/curves@~1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.2.0.tgz#92d7e12e4e49b23105a2555c6984d41733d65c35"
   integrity sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==
   dependencies:
     "@noble/hashes" "1.3.2"
 
-"@noble/curves@~1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.3.0.tgz#01be46da4fd195822dab821e72f71bf4aeec635e"
-  integrity sha512-t01iSXPuN+Eqzb4eBX0S5oubSqXbK/xXa1Ne18Hj8f9pStxztHCE2gfboSp/dZRLSqfuLpRK2nDXDK+W9puocA==
-  dependencies:
-    "@noble/hashes" "1.3.3"
-
-"@noble/curves@~1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.4.0.tgz#f05771ef64da724997f69ee1261b2417a49522d6"
-  integrity sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==
-  dependencies:
-    "@noble/hashes" "1.4.0"
-
 "@noble/hashes@1.3.2":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.2.tgz#6f26dbc8fbc7205873ce3cee2f690eba0d421b39"
   integrity sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==
 
-"@noble/hashes@1.3.3", "@noble/hashes@^1.2.0", "@noble/hashes@~1.3.3":
+"@noble/hashes@^1.2.0", "@noble/hashes@~1.3.2":
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.3.tgz#39908da56a4adc270147bb07968bf3b16cfe1699"
   integrity sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==
-
-"@noble/hashes@1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.4.0.tgz#45814aa329f30e4fe0ba49426f49dfccdd066426"
-  integrity sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -668,18 +649,18 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@scure/base@~1.1.3":
+"@scure/base@^1.1.3":
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.6.tgz#8ce5d304b436e4c84f896e0550c83e4d88cb917d"
   integrity sha512-ok9AWwhcgYuGG3Zfhyqg+zwl+Wn5uE+dwC0NV/2qQkx4dABbb/bx96vWu8NSj+BNjjSjno+JRYRjle1jV08k3g==
 
-"@scure/starknet@~1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@scure/starknet/-/starknet-1.0.0.tgz#4419bc2fdf70f3dd6cb461d36c878c9ef4419f8c"
-  integrity sha512-o5J57zY0f+2IL/mq8+AYJJ4Xpc1fOtDhr+mFQKbHnYFmm3WQrC+8zj2HEgxak1a+x86mhmBC1Kq305KUpVf0wg==
+"@scure/starknet@~0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@scure/starknet/-/starknet-0.3.0.tgz#b8273a42fc721025f8098b1f1d96368a7067e1c4"
+  integrity sha512-Ma66yZlwa5z00qI5alSxdWtIpky5LBhy22acVFdoC5kwwbd9uDyMWEYzWHdNyKmQg9t5Y2UOXzINMeb3yez+Gw==
   dependencies:
-    "@noble/curves" "~1.3.0"
-    "@noble/hashes" "~1.3.3"
+    "@noble/curves" "~1.2.0"
+    "@noble/hashes" "~1.3.2"
 
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"
@@ -945,16 +926,6 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
-abi-wan-kanabi@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/abi-wan-kanabi/-/abi-wan-kanabi-2.2.2.tgz#82c48e8fa08d9016cf92d3d81d494cc60e934693"
-  integrity sha512-sTCv2HyNIj1x2WFUoc9oL8ZT9liosrL+GoqEGZJK1kDND096CfA7lwx06vLxLWMocQ41FQXO3oliwoh/UZHYdQ==
-  dependencies:
-    ansicolors "^0.3.2"
-    cardinal "^2.1.1"
-    fs-extra "^10.0.0"
-    yargs "^17.7.2"
-
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
@@ -1030,11 +1001,6 @@ ansi-styles@^6.0.0, ansi-styles@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.1.tgz#0e62320cf99c21afff3b3012192546aacbfb05c5"
   integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
-
-ansicolors@^0.3.2, ansicolors@~0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/ansicolors/-/ansicolors-0.3.2.tgz#665597de86a9ffe3aa9bfbe6cae5c6ea426b4979"
-  integrity sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==
 
 anymatch@^3.0.3:
   version "3.1.3"
@@ -1440,14 +1406,6 @@ caniuse-lite@^1.0.30001587:
   version "1.0.30001605"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001605.tgz#ca12d7330dd8bcb784557eb9aa64f0037870d9d6"
   integrity sha512-nXwGlFWo34uliI9z3n6Qc0wZaf7zaZWA1CPZ169La5mV3I/gem7bst0vr5XQH5TJXZIMfDeZyOrZnSlVzKxxHQ==
-
-cardinal@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/cardinal/-/cardinal-2.1.1.tgz#7cc1055d822d212954d07b085dea251cc7bc5505"
-  integrity sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==
-  dependencies:
-    ansicolors "~0.3.2"
-    redeyed "~2.1.0"
 
 chalk@5.3.0:
   version "5.3.0"
@@ -2094,7 +2052,7 @@ espree@^9.6.0, espree@^9.6.1:
     acorn-jsx "^5.3.2"
     eslint-visitor-keys "^3.4.1"
 
-esprima@^4.0.0, esprima@~4.0.0:
+esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
@@ -2281,14 +2239,6 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-fetch-cookie@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/fetch-cookie/-/fetch-cookie-3.0.1.tgz#6a77f7495e1a639ae019db916a234db8c85d5963"
-  integrity sha512-ZGXe8Y5Z/1FWqQ9q/CrJhkUD73DyBU9VF0hBQmEO/wPHe4A9PKTjplFDLeFX8aOsYypZUcX5Ji/eByn3VCVO3Q==
-  dependencies:
-    set-cookie-parser "^2.4.8"
-    tough-cookie "^4.0.0"
-
 file-entry-cache@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
@@ -2339,15 +2289,6 @@ for-each@^0.3.3:
   integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
   dependencies:
     is-callable "^1.1.3"
-
-fs-extra@^10.0.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
-  integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
-  dependencies:
-    graceful-fs "^4.2.0"
-    jsonfile "^6.0.1"
-    universalify "^2.0.0"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -2500,7 +2441,7 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
-graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.9:
+graceful-fs@^4.2.9:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -3348,15 +3289,6 @@ json5@^2.2.3:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
-jsonfile@^6.0.1:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
-  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
-  dependencies:
-    universalify "^2.0.0"
-  optionalDependencies:
-    graceful-fs "^4.1.6"
-
 keccak@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/keccak/-/keccak-3.0.4.tgz#edc09b89e633c0549da444432ecf062ffadee86d"
@@ -3464,10 +3396,10 @@ log-update@^6.0.0:
     strip-ansi "^7.1.0"
     wrap-ansi "^9.0.0"
 
-lossless-json@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/lossless-json/-/lossless-json-4.0.1.tgz#d45229e3abb213a0235812780ca894ea8c5b2c6b"
-  integrity sha512-l0L+ppmgPDnb+JGxNLndPtJZGNf6+ZmVaQzoxQm3u6TXmhdnsA+YtdVR8DjzZd/em58686CQhOFDPewfJ4l7MA==
+lossless-json@^2.0.8:
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/lossless-json/-/lossless-json-2.0.11.tgz#3137684c93fd99481c6f99c985efc9c9c5cc76a5"
+  integrity sha512-BP0vn+NGYvzDielvBZaFain/wgeJ1hTvURCqtKvhr1SCPePdaaTanmmcplrHfEJSJOUql7hk4FHwToNJjWRY3g==
 
 lru-cache@^5.1.1:
   version "5.1.1"
@@ -3893,11 +3825,6 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-psl@^1.1.33:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
-  integrity sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==
-
 public-encrypt@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/public-encrypt/-/public-encrypt-4.0.3.tgz#4fcc9d77a07e48ba7527e7cbe0de33d0701331e0"
@@ -3910,7 +3837,7 @@ public-encrypt@^4.0.0:
     randombytes "^2.0.1"
     safe-buffer "^5.1.2"
 
-punycode@^2.1.0, punycode@^2.1.1:
+punycode@^2.1.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
@@ -3919,11 +3846,6 @@ pure-rand@^6.0.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-6.1.0.tgz#d173cf23258231976ccbdb05247c9787957604f2"
   integrity sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==
-
-querystringify@^2.1.1:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
-  integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -3972,13 +3894,6 @@ readable-stream@^3.5.0, readable-stream@^3.6.0:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
-redeyed@~2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/redeyed/-/redeyed-2.1.1.tgz#8984b5815d99cb220469c99eeeffe38913e6cc0b"
-  integrity sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==
-  dependencies:
-    esprima "~4.0.0"
-
 regexp.prototype.flags@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz#138f644a3350f981a858c44f6bb1a61ff59be334"
@@ -3993,11 +3908,6 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
-
-requires-port@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
-  integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
 
 resolve-cwd@^3.0.0:
   version "3.0.0"
@@ -4137,11 +4047,6 @@ semver@^7.0.0, semver@^7.5.2, semver@^7.5.3, semver@^7.5.4:
   dependencies:
     lru-cache "^6.0.0"
 
-set-cookie-parser@^2.4.8:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz#131921e50f62ff1a66a461d7d62d7b21d5d15a51"
-  integrity sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==
-
 set-function-length@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.2.2.tgz#aac72314198eaed975cf77b2c3b6b880695e5449"
@@ -4260,26 +4165,17 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
-starknet-types@^0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/starknet-types/-/starknet-types-0.0.4.tgz#1f92cdde4b2989e1da743c24827960b50057914b"
-  integrity sha512-PklqFeSp9gMqbzW5IbO8l1s3xsNZYkNG/x/gsytgYCIl6H/cqiwCZolVTneyTibvrdHOQ8kP3PXwfdsypudYqw==
-
-starknet@^6.6.6:
-  version "6.7.0"
-  resolved "https://registry.yarnpkg.com/starknet/-/starknet-6.7.0.tgz#004111004d93efd4a5a9da79bd8a97f8d7d50409"
-  integrity sha512-8NMedKBfkg/oZUgTYNw9lKeNoNYakL/Roah2HwKzrVyvDxBs0arrNrR8No8+tTq0wQg0HGu1w+JIObynjHAK3w==
+starknet@^5.24.3:
+  version "5.24.3"
+  resolved "https://registry.yarnpkg.com/starknet/-/starknet-5.24.3.tgz#1d8a84047783ea122a6cf4f2dac59bfa6d628154"
+  integrity sha512-v0TuaNc9iNtHdbIRzX372jfQH1vgx2rwBHQDMqK4DqjJbwFEE5dog8Go6rGiZVW750NqRSWrZ7ahqyRNc3bscg==
   dependencies:
-    "@noble/curves" "~1.4.0"
-    "@scure/base" "~1.1.3"
-    "@scure/starknet" "~1.0.0"
-    abi-wan-kanabi "^2.2.2"
-    fetch-cookie "^3.0.0"
+    "@noble/curves" "~1.2.0"
+    "@scure/base" "^1.1.3"
+    "@scure/starknet" "~0.3.0"
     isomorphic-fetch "^3.0.0"
-    lossless-json "^4.0.1"
+    lossless-json "^2.0.8"
     pako "^2.0.4"
-    starknet-types "^0.0.4"
-    ts-mixer "^6.0.3"
     url-join "^4.0.1"
 
 stream-browserify@^3.0.0:
@@ -4452,16 +4348,6 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-tough-cookie@^4.0.0:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.3.tgz#97b9adb0728b42280aa3d814b6b999b2ff0318bf"
-  integrity sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==
-  dependencies:
-    psl "^1.1.33"
-    punycode "^2.1.1"
-    universalify "^0.2.0"
-    url-parse "^1.5.3"
-
 tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
@@ -4485,11 +4371,6 @@ ts-jest@^29.1.2:
     make-error "1.x"
     semver "^7.5.3"
     yargs-parser "^21.0.1"
-
-ts-mixer@^6.0.3:
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/ts-mixer/-/ts-mixer-6.0.4.tgz#1da39ceabc09d947a82140d9f09db0f84919ca28"
-  integrity sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==
 
 tsconfig-paths@^3.15.0:
   version "3.15.0"
@@ -4594,16 +4475,6 @@ unbox-primitive@^1.0.2:
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
 
-universalify@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.2.0.tgz#6451760566fa857534745ab1dde952d1b1761be0"
-  integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
-
-universalify@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.1.tgz#168efc2180964e6386d061e094df61afe239b18d"
-  integrity sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==
-
 update-browserslist-db@^1.0.13:
   version "1.0.13"
   resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz#3c5e4f5c083661bd38ef64b6328c26ed6c8248c4"
@@ -4623,14 +4494,6 @@ url-join@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/url-join/-/url-join-4.0.1.tgz#b642e21a2646808ffa178c4c5fda39844e12cde7"
   integrity sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==
-
-url-parse@^1.5.3:
-  version "1.5.10"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
-  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
-  dependencies:
-    querystringify "^2.1.1"
-    requires-port "^1.0.0"
 
 utf8@^3.0.0:
   version "3.0.0"
@@ -4782,7 +4645,7 @@ yargs-parser@^21.0.1, yargs-parser@^21.1.1:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
-yargs@^17.3.1, yargs@^17.7.2:
+yargs@^17.3.1:
   version "17.7.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==


### PR DESCRIPTION
* Changed `Account` to `Starknet.Account`, which is capable of executing signed transactions.
* Added `Paraclear.withdraw` which allows to batch a withdraw from Paraclear with an arbitrary transaction to allow bridging the funds to another network.
* Added withdrawal example, covering retrieving balance, socialized loss factor, receivable amount and actual withdrawal.