### PR TITLE
Use token decimals to calculate chain value of receivable amount

### DIFF
--- a/examples/withdrawal.ts
+++ b/examples/withdrawal.ts
@@ -53,6 +53,7 @@ console.log(getBalanceResult); // { size: '100.45' }
 const receivableAmountResult = await Paradex.Paraclear.getReceivableAmount({
   provider: paraclearProvider, // account can be passed as the provider
   config,
+  token: 'USDC',
   amount: '50.4',
 });
 

--- a/src/paraclear.ts
+++ b/src/paraclear.ts
@@ -120,6 +120,11 @@ interface GetReceivableAmountParams {
   readonly config: ParadexConfig;
   readonly provider: Pick<ParaclearProvider, 'callContract'>;
   /**
+   * Token symbol.
+   * @example 'USDC'
+   */
+  readonly token: string;
+  /**
    * Amount of to withdraw from Paradex, as a decimal string.
    * The receivable amount will be calculated based on this amount and
    * can be less than the requested amount if socialized loss is active.
@@ -165,6 +170,12 @@ export async function getReceivableAmount(
     throw new Error('Invalid amount');
   }
 
+  const token = params.config.bridgedTokens[params.token];
+
+  if (token == null) {
+    throw new Error(`Token ${params.token} is not supported`);
+  }
+
   const { socializedLossFactor } = await getSocializedLossFactor({
     config: params.config,
     provider: params.provider,
@@ -176,7 +187,7 @@ export async function getReceivableAmount(
 
   const receivableAmountChainBn = toChainSize(
     receivableAmount.toString(),
-    params.config.paraclearDecimals,
+    token.decimals,
   );
 
   return {

--- a/tests/paraclear.test.ts
+++ b/tests/paraclear.test.ts
@@ -130,20 +130,33 @@ describe('getReceivableAmount', () => {
     const result = await getReceivableAmount({
       config: configFactory(),
       provider: mockProvider,
+      token: 'USDC',
       amount: '100',
     });
 
     expect(result).toStrictEqual({
       receivableAmount: '99',
-      receivableAmountChain: '9900000000',
+      receivableAmountChain: '99000000',
       socializedLossFactor,
     });
+  });
+
+  test('should throw an error if token is not supported', async () => {
+    const result = getReceivableAmount({
+      config: configFactory(),
+      provider: { callContract: jest.fn() },
+      token: 'ASDF',
+      amount: '100',
+    });
+
+    await expect(result).rejects.toThrow('Token ASDF is not supported');
   });
 
   test('should throw an error for invalid amount', async () => {
     const result = getReceivableAmount({
       config: configFactory(),
       provider: { callContract: jest.fn() },
+      token: 'USDC',
       amount: 'not a number',
     });
 
@@ -159,6 +172,7 @@ describe('getReceivableAmount', () => {
     const result = getReceivableAmount({
       config: configFactory(),
       provider: mockProvider,
+      token: 'USDC',
       amount: '100',
     });
 
@@ -174,6 +188,7 @@ describe('getReceivableAmount', () => {
     const result = getReceivableAmount({
       config: configFactory(),
       provider: mockProvider,
+      token: 'USDC',
       amount: '100',
     });
 


### PR DESCRIPTION
The receivable amount must use the token decimals to calculate the chain value instead of Paraclear decimals. For that reason, the `token` parameter needs to be passed to the `getReceivableAmount` function.