### PR TITLE
Fix Paraclear withdrawal function

### DIFF
--- a/examples/withdrawal.ts
+++ b/examples/withdrawal.ts
@@ -53,6 +53,7 @@ console.log(getBalanceResult); // { size: '100.45' }
 const receivableAmountResult = await Paradex.Paraclear.getReceivableAmount({
   provider: paraclearProvider, // account can be passed as the provider
   config,
+  token: 'USDC',
   amount: '50.4',
 });
 

--- a/src/paraclear.ts
+++ b/src/paraclear.ts
@@ -120,6 +120,11 @@ interface GetReceivableAmountParams {
   readonly config: ParadexConfig;
   readonly provider: Pick<ParaclearProvider, 'callContract'>;
   /**
+   * Token symbol.
+   * @example 'USDC'
+   */
+  readonly token: string;
+  /**
    * Amount of to withdraw from Paradex, as a decimal string.
    * The receivable amount will be calculated based on this amount and
    * can be less than the requested amount if socialized loss is active.
@@ -165,6 +170,12 @@ export async function getReceivableAmount(
     throw new Error('Invalid amount');
   }
 
+  const token = params.config.bridgedTokens[params.token];
+
+  if (token == null) {
+    throw new Error(`Token ${params.token} is not supported`);
+  }
+
   const { socializedLossFactor } = await getSocializedLossFactor({
     config: params.config,
     provider: params.provider,
@@ -176,7 +187,7 @@ export async function getReceivableAmount(
 
   const receivableAmountChainBn = toChainSize(
     receivableAmount.toString(),
-    params.config.paraclearDecimals,
+    token.decimals,
   );
 
   return {

--- a/tests/paraclear.test.ts
+++ b/tests/paraclear.test.ts
@@ -1,5 +1,4 @@
 import { ethers } from 'ethers';
-import * as Starknet from 'starknet';
 
 import { fromEthSigner } from '../src/account';
 import { ethersSignerAdapter } from '../src/ethereum-signer';
@@ -213,14 +212,16 @@ describe('withdraw', () => {
       signer,
     });
 
-    jest.spyOn(mockAccount, 'execute').mockResolvedValueOnce({
-      transaction_hash: '0xabcdef123456',
-    });
+    const mockExecute = jest
+      .spyOn(mockAccount, 'execute')
+      .mockResolvedValueOnce({
+        transaction_hash: '0xabcdef123456',
+      });
 
     const bridgeCall = {
       contractAddress: '0xB',
       entrypoint: 'deposit',
-      calldata: Starknet.CallData.compile(['0x12', '100000000']),
+      calldata: ['0x12', '100000000'],
     };
 
     const result = await withdraw({
@@ -235,16 +236,14 @@ describe('withdraw', () => {
       throw new Error('Token USDC is not defined');
     }
 
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    expect(mockAccount.execute).toHaveBeenCalledWith([
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+    const mockExecuteArg1 = mockExecute.mock.calls[0]?.[0];
+    expect(mockExecuteArg1).toStrictEqual([
       {
         contractAddress:
           '0x286003f7c7bfc3f94e8f0af48b48302e7aee2fb13c23b141479ba00832ef2c6',
-        entrypoint: 'initiate_withdrawal',
-        calldata: Starknet.CallData.compile([
-          config.bridgedTokens.USDC.l2TokenAddress,
-          '10000000000',
-        ]),
+        entrypoint: 'withdraw',
+        calldata: [config.bridgedTokens.USDC.l2TokenAddress, '10000000000'],
       },
       bridgeCall,
     ]);

--- a/tests/paraclear.test.ts
+++ b/tests/paraclear.test.ts
@@ -130,20 +130,33 @@ describe('getReceivableAmount', () => {
     const result = await getReceivableAmount({
       config: configFactory(),
       provider: mockProvider,
+      token: 'USDC',
       amount: '100',
     });
 
     expect(result).toStrictEqual({
       receivableAmount: '99',
-      receivableAmountChain: '9900000000',
+      receivableAmountChain: '99000000',
       socializedLossFactor,
     });
+  });
+
+  test('should throw an error if token is not supported', async () => {
+    const result = getReceivableAmount({
+      config: configFactory(),
+      provider: { callContract: jest.fn() },
+      token: 'ASDF',
+      amount: '100',
+    });
+
+    await expect(result).rejects.toThrow('Token ASDF is not supported');
   });
 
   test('should throw an error for invalid amount', async () => {
     const result = getReceivableAmount({
       config: configFactory(),
       provider: { callContract: jest.fn() },
+      token: 'USDC',
       amount: 'not a number',
     });
 
@@ -159,6 +172,7 @@ describe('getReceivableAmount', () => {
     const result = getReceivableAmount({
       config: configFactory(),
       provider: mockProvider,
+      token: 'USDC',
       amount: '100',
     });
 
@@ -174,6 +188,7 @@ describe('getReceivableAmount', () => {
     const result = getReceivableAmount({
       config: configFactory(),
       provider: mockProvider,
+      token: 'USDC',
       amount: '100',
     });
 


### PR DESCRIPTION
* The correct function to call in the Paraclear contract is `withdraw`, not `initiate_withdrawal`.
* Added required `maxFee` to execute a transaction.
* Added missing rounding when converting a number to chain units.