### PR TITLE
Add support for multiple calls to `bridgeCall` in `withdraw`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paradex/sdk",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "JavaScript SDK for Paradex",
   "main": "dist/index.js",
   "files": [

--- a/src/paraclear.ts
+++ b/src/paraclear.ts
@@ -227,7 +227,7 @@ interface WithdrawParams {
    * The bridge call must be made with the receivable amount calculated
    * using {@link getReceivableAmount}.
    */
-  readonly bridgeCall: Starknet.Call;
+  readonly bridgeCall: Starknet.Call | readonly Starknet.Call[];
 }
 
 interface TransactionResult {
@@ -271,7 +271,9 @@ export async function withdraw(
         entrypoint: 'withdraw',
         calldata: [token.l2TokenAddress, chainAmountBn.toString()],
       },
-      params.bridgeCall,
+      ...(Array.isArray(params.bridgeCall)
+        ? params.bridgeCall
+        : [params.bridgeCall]),
     ],
     undefined,
     { maxFee: maxFee.toString() },


### PR DESCRIPTION
In some situations, multiple calls are needed to finalize a withdrawal. An example is to approve before a bridge deposit.

Updated version to 0.4.2 in preparation for release.