### PR TITLE
Support for deriving Paradex account from a Starknet signer

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -7,6 +7,9 @@ module.exports = {
       },
       files: ['src/**/*.ts', 'tests/**/*.ts'],
       extends: ['love', 'prettier'],
+      rules: {
+        '@typescript-eslint/no-unused-vars': 'off',
+      },
     },
   ],
 };

--- a/examples/account-ethereum.ts
+++ b/examples/account-ethereum.ts
@@ -1,0 +1,37 @@
+import { ethers } from 'ethers';
+
+import * as Paradex from '../src/index.js';
+
+declare global {
+  interface Window {
+    ethereum?: ethers.Eip1193Provider;
+  }
+}
+
+// Flow summary:
+//  1. Fetch Paradex config
+//  2. Create Paraclear provider
+//  3. Derive Paradex account from Ethereum signer
+
+// 1. Fetch Paradex config for the relevant environment
+const config = await Paradex.Config.fetchConfig('testnet'); // "testnet" | "mainnet"
+
+// 2. Create Paraclear provider
+const paraclearProvider = new Paradex.ParaclearProvider.DefaultProvider(config);
+
+// 3. Derive Paradex account from Ethereum signer
+
+//  3.1. Get ethers signer (example with injected provider)
+if (window.ethereum == null) throw new Error('Ethereum provider not found');
+const ethersProvider = new ethers.BrowserProvider(window.ethereum);
+const ethersSigner = await ethersProvider.getSigner();
+
+//  3.2. Create Ethereum signer based on ethers signer
+const signer = Paradex.Signer.ethersSignerAdapter(ethersSigner);
+
+//  3.3. Initialize Paradex account with config and Ethereum signer
+const paradexAccount = await Paradex.Account.fromEthSigner({
+  provider: paraclearProvider,
+  config,
+  signer,
+});

--- a/examples/account-starknet.ts
+++ b/examples/account-starknet.ts
@@ -1,0 +1,28 @@
+import * as Starknet from 'starknet';
+
+import * as Paradex from '../src/index.js';
+
+// Flow summary:
+//  1. Fetch Paradex config
+//  2. Create Paraclear provider
+//  3. Derive Paradex account from Starknet signer
+
+// 1. Fetch Paradex config for the relevant environment
+const config = await Paradex.Config.fetchConfig('testnet'); // "testnet" | "mainnet"
+
+// 2. Create Paraclear provider
+const paraclearProvider = new Paradex.ParaclearProvider.DefaultProvider(config);
+
+// 3. Derive Paradex account from Starknet signer
+
+// 3.1 Get hold of user's Starknet account
+const snProvider = new Starknet.RpcProvider();
+const snAccount = new Starknet.Account(snProvider, '0x1234', '0x5678');
+
+// 3.2 Initialize Paradex account with config and Starknet signer
+const paradexAccount = await Paradex.Account.fromStarknetSigner({
+  provider: paraclearProvider,
+  config,
+  signer: snAccount.signer,
+  signerAddress: snAccount.address,
+});

--- a/examples/withdrawal.ts
+++ b/examples/withdrawal.ts
@@ -32,7 +32,7 @@ const ethersSigner = await ethersProvider.getSigner();
 const signer = Paradex.Signer.ethersSignerAdapter(ethersSigner);
 
 //  3.3. Initialize the account with config and Ethereum signer
-const account = await Paradex.Account.fromEthSigner({
+const paradexAccount = await Paradex.Account.fromEthSigner({
   provider: paraclearProvider,
   config,
   signer,
@@ -42,7 +42,7 @@ const account = await Paradex.Account.fromEthSigner({
 const getBalanceResult = await Paradex.Paraclear.getTokenBalance({
   provider: paraclearProvider, // account can be passed as the provider
   config,
-  account,
+  account: paradexAccount,
   token: 'USDC',
 });
 console.log(getBalanceResult); // { size: '100.45' }
@@ -74,7 +74,7 @@ if (Number(receivableAmountResult.socializedLossFactor) !== 0) {
 //  amount to make the bridge call.
 const withdrawResult = await Paradex.Paraclear.withdraw({
   config,
-  account,
+  account: paradexAccount,
   token: 'USDC',
   amount: '50.4',
   bridgeCall: {

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,5 +1,9 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
+  rootDir: './tests',
+
+  resolver: 'jest-ts-webcompat-resolver',
+
   transform: {
     '.ts$': ['ts-jest', { tsconfig: './tsconfig.jest.json' }],
   },

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "ethers": "^6.11.1",
     "husky": "^9.0.11",
     "jest": "^29.7.0",
+    "jest-ts-webcompat-resolver": "^1.0.0",
     "lint-staged": "^15.2.2",
     "prettier": "3.2.5",
     "ts-jest": "^29.1.2",

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,6 +42,8 @@ export interface ParadexConfig {
   readonly starknetFullNodeRpcUrl: string;
   readonly starknetChainId: string;
   readonly l1ChainId: string;
+  /** Derived from `l1ChainId` */
+  readonly l2ChainId: string;
   readonly paraclearAccountHash: Hex;
   readonly paraclearAccountProxyHash: Hex;
   readonly paraclearAddress: Hex;
@@ -108,10 +110,21 @@ export function buildConfig(rawConfig: RawParadexConfig): ParadexConfig {
       rawConfig.starknet_chain_id,
     ),
     l1ChainId: rawConfig.l1_chain_id,
+    l2ChainId: getL2ChainId(rawConfig),
     paraclearAccountHash: rawConfig.paraclear_account_hash,
     paraclearAccountProxyHash: rawConfig.paraclear_account_proxy_hash,
     paraclearAddress: rawConfig.paraclear_address,
     paraclearDecimals: rawConfig.paraclear_decimals,
     bridgedTokens,
   };
+}
+
+function getL2ChainId(rawConfig: RawParadexConfig): string {
+  switch (rawConfig.l1_chain_id) {
+    case '1':
+      return 'SN_MAIN';
+    case '11155111':
+    default:
+      return 'SN_SEPOLIA';
+  }
 }

--- a/src/ethereum-signer.ts
+++ b/src/ethereum-signer.ts
@@ -34,3 +34,26 @@ export function ethersSignerAdapter(
     },
   };
 }
+/**
+ * Returns the typed data that needs to be signed by an Ethereum
+ * wallet in order to generate a Paradex account.
+ * @returns The typed data object.
+ */
+export function buildEthereumStarkKeyTypedData(
+  ethereumChainId: string,
+): TypedData {
+  return {
+    domain: {
+      name: 'Paradex',
+      chainId: ethereumChainId,
+      version: '1',
+    },
+    primaryType: 'Constant',
+    types: {
+      Constant: [{ name: 'action', type: 'string' }],
+    },
+    message: {
+      action: 'STARK Key',
+    },
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,10 @@ import * as _Paraclear from './paraclear.js';
 
 export const Config = { fetchConfig: _Config.fetchConfig };
 
-export const Account = { fromEthSigner: _Account.fromEthSigner };
+export const Account = {
+  fromEthSigner: _Account.fromEthSigner,
+  fromStarknetSigner: _Account.fromStarknetSigner,
+};
 
 export const Signer = { ethersSignerAdapter: _Signer.ethersSignerAdapter };
 

--- a/src/starknet-signer.ts
+++ b/src/starknet-signer.ts
@@ -1,0 +1,75 @@
+import { keyDerivation } from '@starkware-industries/starkware-crypto-utils';
+import type { Signature, SignerInterface, TypedData } from 'starknet';
+import * as Starknet from 'starknet';
+
+export type { SignerInterface as Signer, TypedData, Signature };
+
+export function buildStarknetStarkKeyTypedData(
+  starknetChainId: string,
+): TypedData {
+  return {
+    domain: {
+      name: 'Paradex',
+      chainId: starknetChainId,
+      version: '1',
+    },
+    primaryType: 'Constant',
+    types: {
+      StarkNetDomain: [
+        { name: 'name', type: 'felt' },
+        { name: 'version', type: 'felt' },
+        { name: 'chainId', type: 'felt' },
+      ],
+      Constant: [{ name: 'action', type: 'felt' }],
+    },
+    message: {
+      action: 'STARK Key',
+    },
+  };
+}
+
+type StarknetKeypair = [string, string];
+
+/**
+ * This function borrows from starkware-crypto-utils's implementation
+ * of `getPrivateKeyFromEthSignature()` where a deterministic
+ * signature R segment, is hex encoded as the `keySeed` for
+ * `grindKey()` along the Stark curve.
+ */
+export async function getStarkKeypairFromStarknetSignature(
+  signatureR: string,
+): Promise<StarknetKeypair> {
+  const curve = keyDerivation.StarkExEc;
+  if (curve == null) {
+    throw new Error('StarkExEc curve is not defined');
+  }
+  const r = signatureR.replace(/^0x/u, '');
+  const privateKey = keyDerivation.grindKey(r, curve);
+  const publicKey = keyDerivation.privateToStarkKey(privateKey);
+  return [privateKey, publicKey];
+}
+
+/**
+ * Extracts the R segment from a Starknet signature for key derivation.
+ *  * ArgentX signatures have 2 segments: [R, S]
+ *  * Braavos signatures have 3 segments: [Recovery, R, S]
+ */
+export function getSeedFromStarknetSignature(
+  signature: Starknet.Signature,
+): string {
+  const segments = Starknet.stark.signatureToHexArray(signature);
+
+  if (segments.length === 2) {
+    const [r, _s] = segments;
+    if (r == null) throw new Error('Starknet signature is missing R segment');
+    return r;
+  }
+
+  if (segments.length === 3) {
+    const [_recovery, r, _s] = segments;
+    if (r == null) throw new Error('Starknet signature is missing R segment');
+    return r;
+  }
+
+  throw new Error('Invalid Starknet signature');
+}

--- a/tests/account.test.ts
+++ b/tests/account.test.ts
@@ -1,4 +1,5 @@
 import { ethers } from 'ethers';
+import * as Starknet from 'starknet';
 
 import * as Account from '../src/account';
 import { ethersSignerAdapter } from '../src/ethereum-signer';
@@ -37,6 +38,39 @@ describe('create account from eth signer', () => {
       });
 
       expect(account.address).toBe(testCase.address);
+    }
+  });
+});
+
+describe('create account from starknet signer', () => {
+  test('correct account address is generated', async () => {
+    const testCases = [
+      {
+        snPrivateKey:
+          '0x46063cf2e9c3cbf5cc17ad5fdfce6b6959fede7ceb433dc057a3c90f668004b',
+        snAddress:
+          '0x4383e793c2d1bc29be7647794936371dac6955636f22069a033d4392794780a',
+        paradexAddress:
+          '0x7b21ae25ac9b3f3ff47bb541097332f27252567a5e6f0399ff6f2cfdb1a2cb',
+      },
+    ] as const;
+
+    for (const testCase of testCases) {
+      const snProvider = createMockProvider();
+      const snAccount = new Starknet.Account(
+        snProvider,
+        testCase.snAddress,
+        testCase.snPrivateKey,
+      );
+
+      const account = await Account.fromStarknetSigner({
+        provider: createMockProvider(),
+        config: configFactory(),
+        signer: snAccount.signer,
+        signerAddress: snAccount.address,
+      });
+
+      expect(account.address).toBe(testCase.paradexAddress);
     }
   });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -48,6 +48,7 @@ describe('buildConfig', () => {
         },
       },
       l1ChainId: '11155111',
+      l2ChainId: 'SN_SEPOLIA',
       paraclearAccountHash:
         '0x41cb0280ebadaa75f996d8d92c6f265f6d040bb3ba442e5f86a554f1765244e',
       paraclearAccountProxyHash:

--- a/tests/factories/paradex-config.ts
+++ b/tests/factories/paradex-config.ts
@@ -5,6 +5,7 @@ export function configFactory(): ParadexConfig {
     starknetFullNodeRpcUrl: 'https://example-fullnode-rpc-url.com',
     starknetChainId: '0x505249564154455f534e5f504f54435f5345504f4c4941',
     l1ChainId: '11155111',
+    l2ChainId: 'SN_SEPOLIA',
     paraclearAccountHash:
       '0x41cb0280ebadaa75f996d8d92c6f265f6d040bb3ba442e5f86a554f1765244e',
     paraclearAccountProxyHash:

--- a/tests/starknet-signer.test.ts
+++ b/tests/starknet-signer.test.ts
@@ -1,0 +1,44 @@
+import * as starknetSigner from '../src/starknet-signer';
+
+describe('create STARK keys from Starknet signature', () => {
+  const testCases = [
+    // ArgentX format
+    [
+      '2231984868969048974562485890219247398275701629647443585775236999641425026575',
+      '3466859603989374479029698457644986072084114081755866615133116155642354912863',
+    ],
+    // Braavos format
+    [
+      '1',
+      '2231984868969048974562485890219247398275701629647443585775236999641425026575',
+      '3466859603989374479029698457644986072084114081755866615133116155642354912863',
+    ],
+    // Weierstrass format
+    {
+      r: '2231984868969048974562485890219247398275701629647443585775236999641425026575',
+      s: '3466859603989374479029698457644986072084114081755866615133116155642354912863',
+    },
+  ] as starknetSigner.Signature[];
+
+  for (const starknetSignature of testCases) {
+    it('should extract seed from starknet signature correctly', async () => {
+      const seed =
+        starknetSigner.getSeedFromStarknetSignature(starknetSignature);
+      expect(seed).toBe(
+        '0x4ef42380ace7106e489f211d6ff21bd819043ccf431bbb30aa8fa39bd649e0f',
+      );
+    });
+
+    it('should derive private stark key from starknet signature correctly', async () => {
+      const seed =
+        starknetSigner.getSeedFromStarknetSignature(starknetSignature);
+      const keyPair =
+        await starknetSigner.getStarkKeypairFromStarknetSignature(seed);
+
+      expect(keyPair).toStrictEqual([
+        '46063cf2e9c3cbf5cc17ad5fdfce6b6959fede7ceb433dc057a3c90f668004b',
+        '7a0e7def00d198ccea862678174b5afcc26378d31e1fcdeabb7d5f8d698dbb',
+      ]);
+    });
+  }
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3169,6 +3169,11 @@ jest-snapshot@^29.7.0:
     pretty-format "^29.7.0"
     semver "^7.5.3"
 
+jest-ts-webcompat-resolver@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/jest-ts-webcompat-resolver/-/jest-ts-webcompat-resolver-1.0.0.tgz#a554eb77446e1a8d2aabb810d6302bffaa00095c"
+  integrity sha512-BFoaU7LeYqZNnTYEr6iMRf87xdCQntNc/Wk8YpzDBcuz+CIZ0JsTtzuMAMnKiEgTRTC1wRWLUo2RlVjVijBcHQ==
+
 jest-util@^29.0.0, jest-util@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-29.7.0.tgz#23c2b62bfb22be82b44de98055802ff3710fc0bc"


### PR DESCRIPTION
Paradex users will soon be able create their accounts using a Starknet wallet. This change enables initializing a Paradex account from a Starknet signer through `Account.fromStarknetSigner`.