### PR TITLE
Derive account from Starknet account instead of Starknet signer

### DIFF
--- a/examples/account-starknet.ts
+++ b/examples/account-starknet.ts
@@ -19,10 +19,9 @@ const paraclearProvider = new Paradex.ParaclearProvider.DefaultProvider(config);
 const snProvider = new Starknet.RpcProvider();
 const snAccount = new Starknet.Account(snProvider, '0x1234', '0x5678');
 
-// 3.2 Initialize Paradex account with config and Starknet signer
-const paradexAccount = await Paradex.Account.fromStarknetSigner({
+// 3.2 Initialize Paradex account with config and Starknet account
+const paradexAccount = await Paradex.Account.fromStarknetAccount({
   provider: paraclearProvider,
   config,
-  signer: snAccount.signer,
-  signerAddress: snAccount.address,
+  account: snAccount,
 });

--- a/src/account.ts
+++ b/src/account.ts
@@ -37,28 +37,25 @@ export async function fromEthSigner({
   return new Starknet.Account(provider, address, `0x${privateKey}`);
 }
 
-interface FromStarknetSignerParams {
+interface FromStarknetAccountParams {
   readonly provider: Starknet.ProviderOptions | Starknet.ProviderInterface;
   readonly config: ParadexConfig;
-  // TODO extract type to starknet-signer
-  readonly signer: Starknet.SignerInterface;
-  readonly signerAddress: string;
+  readonly account: Starknet.AccountInterface;
 }
 
 /**
  * Generates a Paradex account from a Starknet signer.
  * @returns The generated Paradex account.
  */
-export async function fromStarknetSigner({
+export async function fromStarknetAccount({
   provider,
   config,
-  signer,
-  signerAddress,
-}: FromStarknetSignerParams): Promise<Account> {
+  account,
+}: FromStarknetAccountParams): Promise<Account> {
   const starknetChainId = config.l2ChainId;
   const starkKeyTypedData =
     starknetSigner.buildStarknetStarkKeyTypedData(starknetChainId);
-  const signature = await signer.signMessage(starkKeyTypedData, signerAddress);
+  const signature = await account.signMessage(starkKeyTypedData);
   const seed = starknetSigner.getSeedFromStarknetSignature(signature);
   const [privateKey, publicKey] =
     await starknetSigner.getStarkKeypairFromStarknetSignature(seed);

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ export const Config = { fetchConfig: _Config.fetchConfig };
 
 export const Account = {
   fromEthSigner: _Account.fromEthSigner,
-  fromStarknetSigner: _Account.fromStarknetSigner,
+  fromStarknetAccount: _Account.fromStarknetAccount,
 };
 
 export const Signer = { ethersSignerAdapter: _Signer.ethersSignerAdapter };

--- a/tests/account.test.ts
+++ b/tests/account.test.ts
@@ -63,11 +63,10 @@ describe('create account from starknet signer', () => {
         testCase.snPrivateKey,
       );
 
-      const account = await Account.fromStarknetSigner({
+      const account = await Account.fromStarknetAccount({
         provider: createMockProvider(),
         config: configFactory(),
-        signer: snAccount.signer,
-        signerAddress: snAccount.address,
+        account: snAccount,
       });
 
       expect(account.address).toBe(testCase.paradexAddress);


### PR DESCRIPTION
Signer won't necessarily have the private key. This is the case for browser wallets, observed on Braavos. Accepting an account instead of a signer allows for proper signing.