### PR TITLE
Extend support for Argent signatures with guardian signer

### DIFF
--- a/src/starknet-account-support.ts
+++ b/src/starknet-account-support.ts
@@ -239,13 +239,13 @@ export class AccountSupport {
       }
 
       case 'argent-v0.4.0-starknet-signer': {
-        if (segments.length === 2) {
+        if (segments.length === 2 || segments.length === 4) {
           const [r, _s] = segments;
           if (r == null)
             throw new Error('Argent signature is missing R segment');
           return r;
         }
-        if (segments.length === 5) {
+        if (segments.length === 5 || segments.length === 9) {
           const [_numSignatures, _sigType, _pubKey, r, _s] = segments;
           if (r == null)
             throw new Error('Argent signature is missing R segment');

--- a/tests/starknet-account-support.test.ts
+++ b/tests/starknet-account-support.test.ts
@@ -97,6 +97,60 @@ test('Argent v0.4.0 with Starknet signer, default signature', async () => {
   expect(seed).toBe('0x4');
 });
 
+test('Argent v0.4.0 with Starknet signer, guardian signature', async () => {
+  const { accountSupport, contract } = setup(
+    '0x036078334509b514626504edc9fb252328d1a240e4e948bef8d0c08dff45927f',
+  );
+
+  jest
+    .spyOn(contract, 'call')
+    .mockResolvedValue(new Starknet.CairoCustomEnum({ Starknet: {} }));
+
+  const result = await accountSupport.check();
+  expect(result.ok).toBe(true);
+
+  const seed = accountSupport.getSeedFromSignature([
+    '0x2', // Signatures count
+    '0x2', // Signer type
+    '0x3', // Public key
+    '0x4', // R
+    '0x5', // S
+    '0x6', // Signer type
+    '0x7', // Public key
+    '0x8', // R
+    '0x9', // S
+  ]);
+  expect(seed).toBe('0x4');
+});
+
+test('Argent v0.4.0 with Starknet signer, unexpected signature', async () => {
+  const { accountSupport, contract } = setup(
+    '0x036078334509b514626504edc9fb252328d1a240e4e948bef8d0c08dff45927f',
+  );
+
+  jest
+    .spyOn(contract, 'call')
+    .mockResolvedValue(new Starknet.CairoCustomEnum({ Starknet: {} }));
+
+  const result = await accountSupport.check();
+  expect(result.ok).toBe(true);
+
+  expect(() => {
+    accountSupport.getSeedFromSignature([
+      '0x2', // Signatures count
+      '0x2', // Signer type
+      '0x3', // Public key
+      '0x4', // R
+      '0x5', // S
+      '0x6', // Signer type
+      '0x7', // Public key
+      '0x8', // R
+      '0x9', // S
+      '0x10', // ???
+    ]);
+  }).toThrow('Unsupported Argent signature');
+});
+
 test('Argent v0.4.0 with Secp256k1 signer', async () => {
   const { accountSupport, contract } = setup(
     '0x036078334509b514626504edc9fb252328d1a240e4e948bef8d0c08dff45927f',


### PR DESCRIPTION
A signature format of `5` segments refer to Argent accounts with a single signer. Accounts that activate a "Smart Account" will have a second signer "Guardian" with the `9` segments. 

This change will also allow a user with a regular account who then signs up for smart account to continue to use Paradex.
