### PR TITLE
Add support for new Braavos 1.1.0 account contract

### DIFF
--- a/tests/starknet-account-support.test.ts
+++ b/tests/starknet-account-support.test.ts
@@ -327,6 +327,90 @@ test('Braavos v1.0.0 single stark signer [signerType,r,s]', async () => {
   expect(seed).toBe('0x2');
 });
 
+test('Braavos v1.1.0 multisig', async () => {
+  const { accountSupport, contract } = setup(
+    '0x02c8c7e6fbcfb3e8e15a46648e8914c6aa1fc506fc1e7fb3d1e19630716174bc',
+  );
+
+  jest.spyOn(contract, 'call').mockResolvedValueOnce(1n);
+
+  const result = await accountSupport.check();
+  expect(result.ok).toBe(false);
+});
+
+test('Braavos v1.1.0 secp256r1 strong signer', async () => {
+  const { accountSupport, contract } = setup(
+    '0x02c8c7e6fbcfb3e8e15a46648e8914c6aa1fc506fc1e7fb3d1e19630716174bc',
+  );
+
+  jest.spyOn(contract, 'call').mockResolvedValueOnce(0n);
+  jest.spyOn(contract, 'call').mockResolvedValueOnce({ secp256r1: 1n });
+
+  const result = await accountSupport.check();
+  expect(result.ok).toBe(false);
+});
+
+test('Braavos v1.1.0 webauthn strong signer', async () => {
+  const { accountSupport, contract } = setup(
+    '0x02c8c7e6fbcfb3e8e15a46648e8914c6aa1fc506fc1e7fb3d1e19630716174bc',
+  );
+
+  jest.spyOn(contract, 'call').mockResolvedValueOnce(0n);
+  jest.spyOn(contract, 'call').mockResolvedValueOnce({ webauthn: [1n] });
+
+  const result = await accountSupport.check();
+  expect(result.ok).toBe(false);
+});
+
+test('Braavos v1.1.0 multiple stark signers', async () => {
+  const { accountSupport, contract } = setup(
+    '0x02c8c7e6fbcfb3e8e15a46648e8914c6aa1fc506fc1e7fb3d1e19630716174bc',
+  );
+
+  jest.spyOn(contract, 'call').mockResolvedValueOnce(0n);
+  jest.spyOn(contract, 'call').mockResolvedValueOnce({ stark: [1n, 2n] });
+
+  const result = await accountSupport.check();
+  expect(result.ok).toBe(false);
+});
+
+test('Braavos v1.1.0 single stark signer [r,s]', async () => {
+  const { accountSupport, contract } = setup(
+    '0x02c8c7e6fbcfb3e8e15a46648e8914c6aa1fc506fc1e7fb3d1e19630716174bc',
+  );
+
+  jest.spyOn(contract, 'call').mockResolvedValueOnce(0n);
+  jest.spyOn(contract, 'call').mockResolvedValueOnce({ stark: [1n] });
+
+  const result = await accountSupport.check();
+  expect(result.ok).toBe(true);
+
+  const seed = accountSupport.getSeedFromSignature([
+    '0x1', // R
+    '0x2', // S
+  ]);
+  expect(seed).toBe('0x1');
+});
+
+test('Braavos v1.1.0 single stark signer [signerType,r,s]', async () => {
+  const { accountSupport, contract } = setup(
+    '0x02c8c7e6fbcfb3e8e15a46648e8914c6aa1fc506fc1e7fb3d1e19630716174bc',
+  );
+
+  jest.spyOn(contract, 'call').mockResolvedValueOnce(0n);
+  jest.spyOn(contract, 'call').mockResolvedValueOnce({ stark: [1n] });
+
+  const result = await accountSupport.check();
+  expect(result.ok).toBe(true);
+
+  const seed = accountSupport.getSeedFromSignature([
+    '0x1', // Signer type
+    '0x2', // R
+    '0x3', // S
+  ]);
+  expect(seed).toBe('0x2');
+});
+
 test('Unknown class hash', async () => {
   const { accountSupport } = setup('0x0000');
 


### PR DESCRIPTION
Braavos has upgraded their account contract to v1.1.0. This commit adds support for the new contract.

The signature format is the same as v1.0.0.