### PR TITLE
Check if wallet generates deterministic signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Have a feature to request or a bug to report?
 Drop us a message on [Discord].
 
 [Discord]: https://discord.gg/paradex
-[get in touch]: #get-in-touch
 
 ## Warning
 

--- a/src/account.ts
+++ b/src/account.ts
@@ -125,7 +125,7 @@ function generateAccountAddress({
 /**
  * Checks if starknet signatures are equal.
  */
-function isStarknetSignatureEqual(
+export function isStarknetSignatureEqual(
   signature: Starknet.Signature,
   additionalSignature: Starknet.Signature,
 ): boolean {

--- a/src/account.ts
+++ b/src/account.ts
@@ -27,6 +27,11 @@ export async function fromEthSigner({
     config.ethereumChainId,
   );
   const seed = await signer.signTypedData(starkKeyTypedData);
+  const additionalSeed = await signer.signTypedData(starkKeyTypedData);
+  if (seed !== additionalSeed)
+    throw new Error(
+      'Wallet does not support deterministic signing. Please use different wallet.',
+    );
   const privateKey = keyDerivation.getPrivateKeyFromEthSignature(seed);
   const publicKey = keyDerivation.privateToStarkKey(privateKey);
   const address = generateAccountAddress({
@@ -65,6 +70,11 @@ export async function fromStarknetAccount({
       starknetSigner.getPublicProvider(config.starknetChainId),
   );
   const signature = await account.signMessage(starkKeyTypedData);
+  const additionalSignature = await account.signMessage(starkKeyTypedData);
+  if (!isStarknetSignatureDeterministic(signature, additionalSignature))
+    throw new Error(
+      'Wallet does not support deterministic signing. Please use different wallet.',
+    );
   const seed = accountSupport.getSeedFromSignature(signature);
   const [privateKey, publicKey] =
     await starknetSigner.getStarkKeypairFromStarknetSignature(seed);
@@ -110,4 +120,27 @@ function generateAccountAddress({
   );
 
   return address as Hex;
+}
+
+/**
+ * Checks if starknet signature is valid.
+ */
+function isStarknetSignatureDeterministic(
+  signature: Starknet.Signature,
+  additionalSignature: Starknet.Signature,
+): boolean {
+  if (Array.isArray(signature) && Array.isArray(additionalSignature)) {
+    return (
+      signature.length === additionalSignature.length &&
+      signature.every((value, index) => value === additionalSignature[index])
+    );
+  }
+  // Cast Starknet.WeierstrassSignatureType
+  const signatureWeierstrass = signature as Starknet.WeierstrassSignatureType;
+  const additionalSignatureWeierstrass =
+    additionalSignature as Starknet.WeierstrassSignatureType;
+  return (
+    signatureWeierstrass.r === additionalSignatureWeierstrass.r &&
+    signatureWeierstrass.s === additionalSignatureWeierstrass.s
+  );
 }

--- a/src/account.ts
+++ b/src/account.ts
@@ -71,7 +71,7 @@ export async function fromStarknetAccount({
   );
   const signature = await account.signMessage(starkKeyTypedData);
   const additionalSignature = await account.signMessage(starkKeyTypedData);
-  if (!isStarknetSignatureDeterministic(signature, additionalSignature))
+  if (!isStarknetSignatureEqual(signature, additionalSignature))
     throw new Error(
       'Wallet does not support deterministic signing. Please use different wallet.',
     );
@@ -123,9 +123,9 @@ function generateAccountAddress({
 }
 
 /**
- * Checks if starknet signature is valid.
+ * Checks if starknet signatures are equal.
  */
-function isStarknetSignatureDeterministic(
+function isStarknetSignatureEqual(
   signature: Starknet.Signature,
   additionalSignature: Starknet.Signature,
 ): boolean {


### PR DESCRIPTION
This pull request includes changes to enhance the deterministic signing process and improve error handling in the `src/account.ts` file, as well as a minor update to the `README.md` file.

Enhancements to deterministic signing:

* [`src/account.ts`](diffhunk://#diff-ae151444b91b7e5e0a6aa753024f7900f0ff0447afaa2d18ad6619d5c3e12318R30-R34): Added a check for deterministic signing by comparing the initial seed with an additional seed in the `fromEthSigner` function. If they differ, an error is thrown to indicate the wallet does not support deterministic signing.
* [`src/account.ts`](diffhunk://#diff-ae151444b91b7e5e0a6aa753024f7900f0ff0447afaa2d18ad6619d5c3e12318R73-R77): Implemented a similar check in the `fromStarknetAccount` function by comparing the initial signature with an additional signature using the new `isStarknetSignatureDeterministic` function.
* [`src/account.ts`](diffhunk://#diff-ae151444b91b7e5e0a6aa753024f7900f0ff0447afaa2d18ad6619d5c3e12318R124-R146): Added the `isStarknetSignatureDeterministic` function to validate the deterministic nature of Starknet signatures by comparing the components of the signatures.

Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L28): Removed the unused `[get in touch]` reference link from the documentation.