### PR TITLE
 Add custom RPC support and update Starknet public endpoints

### DIFF
--- a/examples/account-starknet.ts
+++ b/examples/account-starknet.ts
@@ -16,6 +16,8 @@ const snAccount = new Starknet.Account({
 const client = await Paradex.Client.fromStarknetAccount({
   config,
   account: snAccount,
+  // Optional: Provide custom Starknet RPC URL to skip using public provider
+  rpcUrl: 'https://rpc.starknet.lava.build/rpc/v0_9',
 });
 
 console.log(`Paradex address: ${client.getAddress()}`);

--- a/src/account.ts
+++ b/src/account.ts
@@ -82,6 +82,7 @@ interface DeriveFromStarknetAccountParams {
   readonly config: ParadexConfig;
   readonly account: Starknet.AccountInterface;
   readonly starknetProvider?: Starknet.ProviderInterface;
+  readonly rpcUrl?: string;
 }
 
 /**
@@ -94,15 +95,21 @@ export async function deriveFromStarknetAccount({
   config,
   account,
   starknetProvider,
+  rpcUrl,
 }: DeriveFromStarknetAccountParams): Promise<AccountCredentials> {
   const starkKeyTypedData = starknetSigner.buildStarknetStarkKeyTypedData(
     config.starknetChainId,
   );
 
+  const provider =
+    starknetProvider ??
+    (rpcUrl != null
+      ? new Starknet.RpcProvider({ nodeUrl: rpcUrl })
+      : starknetSigner.getPublicProvider(config.starknetChainId));
+
   const accountSupport = await starknetSigner.getAccountSupport(
     account,
-    starknetProvider ??
-      starknetSigner.getPublicProvider(config.starknetChainId),
+    provider,
   );
   const signature = await account.signMessage(starkKeyTypedData);
   const additionalSignature = await account.signMessage(starkKeyTypedData);
@@ -130,6 +137,7 @@ interface FromStarknetAccountParams {
   readonly config: ParadexConfig;
   readonly account: Starknet.AccountInterface;
   readonly starknetProvider?: Starknet.ProviderInterface;
+  readonly rpcUrl?: string;
 }
 
 /**
@@ -142,11 +150,13 @@ export async function fromStarknetAccount({
   config,
   account,
   starknetProvider,
+  rpcUrl,
 }: FromStarknetAccountParams): Promise<Account> {
   const credentials = await deriveFromStarknetAccount({
     config,
     account,
     starknetProvider,
+    rpcUrl,
   });
   return new Starknet.Account({
     provider,

--- a/src/client.ts
+++ b/src/client.ts
@@ -19,6 +19,7 @@ export interface CreateClientFromStarknetAccountParams {
   readonly config: ParadexConfig;
   readonly account: Starknet.AccountInterface;
   readonly starknetProvider?: Starknet.ProviderInterface;
+  readonly rpcUrl?: string;
 }
 
 export interface TokenBalance {
@@ -91,12 +92,14 @@ export class ParadexClient {
     config,
     account,
     starknetProvider,
+    rpcUrl,
   }: CreateClientFromStarknetAccountParams): Promise<ParadexClient> {
     // Derive credentials internally (privateKey never exposed)
     const credentials = await deriveFromStarknetAccount({
       config,
       account,
       starknetProvider,
+      rpcUrl,
     });
 
     // Create authenticated provider

--- a/src/starknet-signer.ts
+++ b/src/starknet-signer.ts
@@ -86,12 +86,13 @@ export async function getAccountSupport(
 }
 
 const RPC_NODES_MAINNET: readonly string[] = [
-  'https://starknet-mainnet.public.blastapi.io',
-  'https://free-rpc.nethermind.io/mainnet-juno',
+  'https://rpc.starknet.lava.build/rpc/v0_9',
+  'https://api-starknet-mainnet.n.dwellir.com/79e509c1-b94b-4146-ac66-efdc56786415/rpc/v0_9',
 ];
 const RPC_NODES_TESTNET: readonly string[] = [
-  'https://starknet-sepolia.public.blastapi.io',
-  'https://free-rpc.nethermind.io/sepolia-juno',
+  'https://rpc.starknet-testnet.lava.build/rpc/v0_9',
+  'https://api-starknet-sepolia.n.dwellir.com/79e509c1-b94b-4146-ac66-efdc56786415/rpc/v0_9',
+  'https://starknet.api.onfinality.io/public',
 ];
 
 export function getPublicProvider(chainId: string): Starknet.ProviderInterface {


### PR DESCRIPTION
Allows users to specify custom RPC URLs when creating
clients from Starknet accounts, providing flexibility
to use their own infrastructure.

Also updates the default public RPC endpoints to currently
active providers, replacing discontinued services that may
prevent wallet initialisation on testnet and mainnet.